### PR TITLE
chore: run go generate after an upgrade

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,7 +11,7 @@
   ],
   "postUpdateOptions": [
     "gomodTidy",
-    "gomodUpdateImportPaths",
+    "gomodUpdateImportPaths"
   ],
   "postUpgradeTasks": {
     "commands": ["go generate ./..."],

--- a/default.json
+++ b/default.json
@@ -11,8 +11,12 @@
   ],
   "postUpdateOptions": [
     "gomodTidy",
-    "gomodUpdateImportPaths"
+    "gomodUpdateImportPaths",
   ],
+  "postUpgradeTasks": {
+    "commands": ["go generate ./..."],
+    "fileFilters": ["**/*.go", "**/*.graphql", "go.sum"]
+  },
   "packageRules": [
     {
       "groupName": "go opentelemetry packages and libraries",


### PR DESCRIPTION
This will update the config for renovate to run `go generate ./...` after performing updates. This is helpful when gqlgen or ent get upgraded to ensure the latest files are being generated. 