### PR TITLE
chore: revert run go generate after an upgrade

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,10 +13,6 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
-  "postUpgradeTasks": {
-    "commands": ["go generate ./..."],
-    "fileFilters": ["**/*.go", "**/*.graphql", "go.sum"]
-  },
   "packageRules": [
     {
       "groupName": "go opentelemetry packages and libraries",


### PR DESCRIPTION
Hosted renovate doesn't allow running commands